### PR TITLE
fix auth in prod

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -18,16 +18,19 @@ use std::net::SocketAddr;
 async fn main() {
     let db = db::get();
 
-    let router = Router::new()
-        .route("/api/auth/login/:user_id", get(login))
-        .route("/api/users/me", get(whoami))
-        .route("/api/pages", post(create_page))
-        .route("/api/widgets", post(create_widget))
-        .route("/api/bookmarks", get(get_bookmarks))
-        .route("/api/bookmarks", post(create_bookmark))
-        .route("/api/bookmarks/:bookmark_id", delete(delete_bookmark))
+    let api_router = Router::new()
+        .route("/auth/login/:user_id", get(login))
+        .route("/users/me", get(whoami))
+        .route("/pages", post(create_page))
+        .route("/widgets", post(create_widget))
+        .route("/bookmarks", get(get_bookmarks))
+        .route("/bookmarks", post(create_bookmark))
+        .route("/bookmarks/:bookmark_id", delete(delete_bookmark))
         .with_state(db)
-        .layer(auth::extension())
+        .layer(auth::extension());
+
+    let router = Router::new()
+        .nest("/api", api_router)
         .merge(frontend::frontend_routes());
 
     // run it


### PR DESCRIPTION
I have no idea why this happened in prod but not locally.

For the record, logging in as an already existing user worked fine.
But when loggin in as a new user, the response was *bad gateway*,
something our own login handler would never respond with.
Meaning that, the request wouldn't even reach the handler?

But how could the *router* know which users already exist in the
database and which don't? Truly a mistery.

Separating the frontend routes from the api routes cleanly
seems to have fixed the problem. Something must've caused the router
to send the request to the frontend router instead of the login
handler.
